### PR TITLE
Fix UI issues with event import and display

### DIFF
--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -56,7 +56,7 @@
     <%= form.text_area :description,
           rows: 3,
           placeholder: "Description (optional)",
-          class: "w-full rounded-2xl border border-slate-300/80 bg-white px-4 py-3 text-base text-slate-900 placeholder:text-slate-400 focus:border-blue-500 focus:outline-none focus:ring-4 focus:ring-blue-400/30 resize-none" %>
+          class: "w-full rounded-2xl border border-slate-300/80 bg-white px-4 py-3 text-base text-slate-900 placeholder:text-slate-400 focus:border-blue-500 focus:outline-none focus:ring-4 focus:ring-blue-400/30 resize-y" %>
   </div>
 
   <div>

--- a/app/views/events/_import_form.html.erb
+++ b/app/views/events/_import_form.html.erb
@@ -28,7 +28,7 @@
          data-action="click->import-preview#cancel"></div>
 
     <%# Modal panel %>
-    <div class="flex min-h-full items-center justify-center p-4">
+    <div class="flex min-h-screen items-center justify-center p-4">
       <div class="relative w-full max-w-lg rounded-2xl bg-white shadow-xl">
         <%# Header %>
         <div class="flex items-center justify-between border-b border-slate-200 px-6 py-4">

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -37,14 +37,14 @@
       <% if @event.location.present? %>
         <div>
           <dt class="font-medium text-slate-500">Location</dt>
-          <dd class="text-slate-900"><%= @event.location %></dd>
+          <dd class="text-slate-900 break-words"><%= @event.location %></dd>
         </div>
       <% end %>
 
       <% if @event.description.present? %>
         <div>
           <dt class="font-medium text-slate-500">Description</dt>
-          <dd class="text-slate-900 whitespace-pre-wrap"><%= @event.description %></dd>
+          <dd class="text-slate-900 whitespace-pre-wrap break-words"><%= @event.description %></dd>
         </div>
       <% end %>
 


### PR DESCRIPTION
  - Fix import preview modal not visible on long pages by using min-h-screen instead of min-h-full for proper viewport centering
  - Fix long URLs overflowing in event show page by adding break-words to location and description fields
  - Allow vertical resizing of description textarea in event form