### PR TITLE
Add daily digest API endpoint

### DIFF
--- a/app/controllers/api/v1/daily_digest_controller.rb
+++ b/app/controllers/api/v1/daily_digest_controller.rb
@@ -1,0 +1,16 @@
+module Api
+  module V1
+    class DailyDigestController < BaseController
+      require_scope :read
+
+      def show
+        date = params[:date] ? Date.parse(params[:date]) : Time.current.to_date
+        service = DailyDigestService.new(current_user, date: date)
+
+        render json: service.call.merge(generated_at: Time.current.iso8601)
+      rescue ArgumentError => e
+        render json: { error: "Invalid date format" }, status: :bad_request
+      end
+    end
+  end
+end

--- a/app/services/daily_digest_service.rb
+++ b/app/services/daily_digest_service.rb
@@ -1,0 +1,134 @@
+class DailyDigestService
+  def initialize(user, date: nil)
+    @user = user
+    @date = date || Time.current.to_date
+  end
+
+  def call
+    {
+      date: @date.iso8601,
+      todos: {
+        today: todays_todos,
+        overdue: overdue_todos,
+        tomorrow: tomorrows_todos,
+        this_week: this_weeks_todos
+      },
+      events: {
+        today: todays_events,
+        this_week: this_weeks_events
+      },
+      summary: summary
+    }
+  end
+
+  private
+
+  def todays_todos
+    @user.todos
+      .includes(milestone: :project)
+      .where(completed_at: nil, priority_window: "today")
+      .order(:position)
+      .map { |todo| format_todo(todo) }
+  end
+
+  def overdue_todos
+    @user.todos
+      .includes(milestone: :project)
+      .where(completed_at: nil)
+      .where.not(priority_window: [ "today", "tomorrow", "this_week", "next_week" ])
+      .order(created_at: :desc)
+      .map { |todo| format_todo(todo) }
+  end
+
+  def tomorrows_todos
+    @user.todos
+      .includes(milestone: :project)
+      .where(completed_at: nil, priority_window: "tomorrow")
+      .order(:position)
+      .map { |todo| format_todo(todo) }
+  end
+
+  def this_weeks_todos
+    @user.todos
+      .includes(milestone: :project)
+      .where(completed_at: nil, priority_window: "this_week")
+      .order(:position)
+      .map { |todo| format_todo(todo) }
+  end
+
+  def todays_events
+    @user.events
+      .left_joins(:project)
+      .where("projects.archived_at IS NULL OR events.project_id IS NULL")
+      .includes(:project)
+      .for_date_range(@date, @date)
+      .map { |event| format_event(event) }
+  end
+
+  def this_weeks_events
+    week_end = @date.end_of_week
+    @user.events
+      .left_joins(:project)
+      .where("projects.archived_at IS NULL OR events.project_id IS NULL")
+      .includes(:project)
+      .for_date_range(@date, week_end)
+      .map { |event| format_event(event) }
+  end
+
+  def summary
+    {
+      todos_count: @user.todos.where(completed_at: nil, priority_window: "today").count,
+      overdue_count: @user.todos
+        .where(completed_at: nil)
+        .where.not(priority_window: [ "today", "tomorrow", "this_week", "next_week" ])
+        .count,
+      events_today: @user.events.for_date_range(@date, @date).count,
+      events_this_week: @user.events
+        .for_date_range(@date, @date.end_of_week)
+        .count
+    }
+  end
+
+  def format_todo(todo)
+    {
+      id: todo.id,
+      title: todo.title,
+      priority_window: todo.priority_window,
+      position: todo.position,
+      created_at: todo.created_at.iso8601,
+      milestone: format_milestone(todo.milestone),
+      project: format_project(todo.milestone&.project)
+    }
+  end
+
+  def format_event(event)
+    {
+      id: event.id,
+      title: event.title,
+      description: event.description,
+      starts_at: event.starts_at.iso8601,
+      ends_at: event.ends_at.iso8601,
+      all_day: event.all_day,
+      event_type: event.event_type,
+      project: format_project(event.project)
+    }
+  end
+
+  def format_milestone(milestone)
+    return nil unless milestone
+
+    {
+      id: milestone.id,
+      name: milestone.name
+    }
+  end
+
+  def format_project(project)
+    return nil unless project
+
+    {
+      id: project.id,
+      name: project.name
+    }
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -58,11 +58,12 @@ Rails.application.routes.draw do
       end
     end
 
-    # Versioned API for external access via tokens
+      # Versioned API for external access via tokens
     namespace :v1 do
       get "docs", to: "docs#show"
       get "trmnl/dashboard", to: "trmnl#dashboard"
       get "activity", to: "activity#show"
+      get "daily_digest", to: "daily_digest#show"
 
       resources :projects do
         member do


### PR DESCRIPTION
This PR adds a new `/api/v1/daily_digest` endpoint to support automated morning email summaries.

## Changes
- **DailyDigestService**: Aggregates todos by priority window (today, overdue, tomorrow, this_week) and events for today/this week
- **DailyDigestController**: RESTful endpoint with optional date parameter
- **Route**: Added `GET /api/v1/daily_digest` to the v1 API namespace

## Use Case
Enables external services (like cron jobs or agents) to fetch a consolidated daily/weekly summary of todos and calendar events for generating morning briefing emails.

## Example Response
```json
{
  "date": "2026-02-15",
  "todos": {
    "today": [...],
    "overdue": [...],
    "tomorrow": [...],
    "this_week": [...]
  },
  "events": {
    "today": [...],
    "this_week": [...]
  },
  "summary": {
    "todos_count": 5,
    "overdue_count": 2,
    "events_today": 3,
    "events_this_week": 12
  }
}
```